### PR TITLE
Add kwargs passing to `_gen_quimb_gates`

### DIFF
--- a/src/qiskit_quimb/circuit.py
+++ b/src/qiskit_quimb/circuit.py
@@ -49,30 +49,30 @@ def quimb_gates(circuit: QuantumCircuit) -> list[quimb.tensor.Gate]:
     return gates
 
 
-def _gen_quimb_gates(op: Instruction, qubits: list[int]) -> Iterator[quimb.tensor.Gate]:
+def _gen_quimb_gates(op: Instruction, qubits: list[int], **kwargs) -> Iterator[quimb.tensor.Gate]:
     """Convert a Qiskit gate to quimb gates."""
     match op.name:
         case "barrier":
             pass
         case "ccx":
-            yield quimb.tensor.Gate("CCX", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("CCX", params=[], qubits=qubits, **kwargs)
         case "ccz":
-            yield quimb.tensor.Gate("CCZ", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("CCZ", params=[], qubits=qubits, **kwargs)
         case "cp":
             (theta,) = op.params
-            yield quimb.tensor.Gate("CU1", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("CU1", params=[theta], qubits=qubits, **kwargs)
         case "cx":
-            yield quimb.tensor.Gate("CX", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("CX", params=[], qubits=qubits, **kwargs)
         case "cy":
-            yield quimb.tensor.Gate("CY", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("CY", params=[], qubits=qubits, **kwargs)
         case "cz":
-            yield quimb.tensor.Gate("CZ", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("CZ", params=[], qubits=qubits, **kwargs)
         case "h":
-            yield quimb.tensor.Gate("H", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("H", params=[], qubits=qubits, **kwargs)
         case "id":
-            yield quimb.tensor.Gate("IDEN", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("IDEN", params=[], qubits=qubits, **kwargs)
         case "iswap":
-            yield quimb.tensor.Gate("ISWAP", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("ISWAP", params=[], qubits=qubits, **kwargs)
         case "measure":
             raise ValueError(
                 "Encountered a measurement gate, which is not allowed. "
@@ -80,46 +80,46 @@ def _gen_quimb_gates(op: Instruction, qubits: list[int]) -> Iterator[quimb.tenso
             )
         case "p":
             (theta,) = op.params
-            yield quimb.tensor.Gate("U1", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("U1", params=[theta], qubits=qubits, **kwargs)
         case "rx":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RX", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RX", params=[theta], qubits=qubits, **kwargs)
         case "rxx":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RXX", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RXX", params=[theta], qubits=qubits, **kwargs)
         case "ryy":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RYY", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RYY", params=[theta], qubits=qubits, **kwargs)
         case "rzz":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RZZ", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RZZ", params=[theta], qubits=qubits, **kwargs)
         case "ry":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RY", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RY", params=[theta], qubits=qubits, **kwargs)
         case "rz":
             (theta,) = op.params
-            yield quimb.tensor.Gate("RZ", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("RZ", params=[theta], qubits=qubits, **kwargs)
         case "s":
-            yield quimb.tensor.Gate("S", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("S", params=[], qubits=qubits, **kwargs)
         case "sdg":
-            yield quimb.tensor.Gate("SDG", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("SDG", params=[], qubits=qubits, **kwargs)
         case "swap":
-            yield quimb.tensor.Gate("SWAP", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("SWAP", params=[], qubits=qubits, **kwargs)
         case "t":
-            yield quimb.tensor.Gate("T", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("T", params=[], qubits=qubits, **kwargs)
         case "tdg":
-            yield quimb.tensor.Gate("TDG", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("TDG", params=[], qubits=qubits, **kwargs)
         case "u1":
             (theta,) = op.params
-            yield quimb.tensor.Gate("U1", params=[theta], qubits=qubits)
+            yield quimb.tensor.Gate("U1", params=[theta], qubits=qubits, **kwargs)
         case "u2":
             (phi, lam) = op.params
-            yield quimb.tensor.Gate("U2", params=[phi, lam], qubits=qubits)
+            yield quimb.tensor.Gate("U2", params=[phi, lam], qubits=qubits, **kwargs)
         case "u3":
             (theta, phi, lam) = op.params
-            yield quimb.tensor.Gate("U3", params=[theta, phi, lam], qubits=qubits)
+            yield quimb.tensor.Gate("U3", params=[theta, phi, lam], qubits=qubits, **kwargs)
         case "x":
-            yield quimb.tensor.Gate("X", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("X", params=[], qubits=qubits, **kwargs)
         case "xx_plus_yy":
             theta, beta = op.params
             phi = beta + 0.5 * math.pi
@@ -128,8 +128,8 @@ def _gen_quimb_gates(op: Instruction, qubits: list[int]) -> Iterator[quimb.tenso
             yield quimb.tensor.Gate("GIVENS", params=[0.5 * theta], qubits=[a, b])
             yield quimb.tensor.Gate("RZ", params=[-phi], qubits=[a])
         case "y":
-            yield quimb.tensor.Gate("Y", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("Y", params=[], qubits=qubits, **kwargs)
         case "z":
-            yield quimb.tensor.Gate("Z", params=[], qubits=qubits)
+            yield quimb.tensor.Gate("Z", params=[], qubits=qubits, **kwargs)
         case _:
             raise ValueError(f"Unsupported gate: {op.name}.")

--- a/src/qiskit_quimb/circuit.py
+++ b/src/qiskit_quimb/circuit.py
@@ -124,9 +124,9 @@ def _gen_quimb_gates(op: Instruction, qubits: list[int], **kwargs) -> Iterator[q
             theta, beta = op.params
             phi = beta + 0.5 * math.pi
             a, b = qubits
-            yield quimb.tensor.Gate("RZ", params=[phi], qubits=[a])
-            yield quimb.tensor.Gate("GIVENS", params=[0.5 * theta], qubits=[a, b])
-            yield quimb.tensor.Gate("RZ", params=[-phi], qubits=[a])
+            yield quimb.tensor.Gate("RZ", params=[phi], qubits=[a], **kwargs)
+            yield quimb.tensor.Gate("GIVENS", params=[0.5 * theta], qubits=[a, b], **kwargs)
+            yield quimb.tensor.Gate("RZ", params=[-phi], qubits=[a], **kwargs)
         case "y":
             yield quimb.tensor.Gate("Y", params=[], qubits=qubits, **kwargs)
         case "z":

--- a/src/qiskit_quimb/circuit.py
+++ b/src/qiskit_quimb/circuit.py
@@ -49,7 +49,9 @@ def quimb_gates(circuit: QuantumCircuit) -> list[quimb.tensor.Gate]:
     return gates
 
 
-def _gen_quimb_gates(op: Instruction, qubits: list[int], **kwargs) -> Iterator[quimb.tensor.Gate]:
+def _gen_quimb_gates(
+    op: Instruction, qubits: list[int], **kwargs
+) -> Iterator[quimb.tensor.Gate]:
     """Convert a Qiskit gate to quimb gates."""
     match op.name:
         case "barrier":
@@ -117,7 +119,9 @@ def _gen_quimb_gates(op: Instruction, qubits: list[int], **kwargs) -> Iterator[q
             yield quimb.tensor.Gate("U2", params=[phi, lam], qubits=qubits, **kwargs)
         case "u3":
             (theta, phi, lam) = op.params
-            yield quimb.tensor.Gate("U3", params=[theta, phi, lam], qubits=qubits, **kwargs)
+            yield quimb.tensor.Gate(
+                "U3", params=[theta, phi, lam], qubits=qubits, **kwargs
+            )
         case "x":
             yield quimb.tensor.Gate("X", params=[], qubits=qubits, **kwargs)
         case "xx_plus_yy":
@@ -125,7 +129,9 @@ def _gen_quimb_gates(op: Instruction, qubits: list[int], **kwargs) -> Iterator[q
             phi = beta + 0.5 * math.pi
             a, b = qubits
             yield quimb.tensor.Gate("RZ", params=[phi], qubits=[a], **kwargs)
-            yield quimb.tensor.Gate("GIVENS", params=[0.5 * theta], qubits=[a, b], **kwargs)
+            yield quimb.tensor.Gate(
+                "GIVENS", params=[0.5 * theta], qubits=[a, b], **kwargs
+            )
             yield quimb.tensor.Gate("RZ", params=[-phi], qubits=[a], **kwargs)
         case "y":
             yield quimb.tensor.Gate("Y", params=[], qubits=qubits, **kwargs)


### PR DESCRIPTION
This adds kwarg support to `_gen_quimb_gates`; it simply passes any kwargs along to the `Gate` constructor(s).  It can be useful to pass `parametrize=True` here, and likely other things as well.