### PR TITLE
Use `sphinx.ext.githubpages` to add `.nojekyll` file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.extlinks",
+    "sphinx.ext.githubpages",
     "sphinx_autodoc_typehints",
     "myst_parser",
     "nbsphinx",


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html

This differs from 3b977a0f19bff82b2603a46d3a262d2c05e8daa4 (later de3cc2f315772579ecee43ecda78166d053e2ca6) because that commit put the file on `main`, not on the `gh-pages` branch.

Closes #11