### PR TITLE
Revert "Use `sphinx.ext.githubpages` to add `.nojekyll` file"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.extlinks",
-    "sphinx.ext.githubpages",
     "sphinx_autodoc_typehints",
     "myst_parser",
     "nbsphinx",


### PR DESCRIPTION
Reverts qiskit-community/qiskit-quimb#17

I manually added `.nojekyll` to the `gh-pages` branch. I don't think this Sphinx extension is needed.