### PR TITLE
add contengra recommended optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,18 @@ dev = [
     "ruff",
     "sphinx",
     "sphinx-autodoc-typehints",
+    # contengra recommended selection of optional dependencies
+    "autoray",
+    "cmaes",
+    "cotengrust",
+    "cytoolz",
+    "kahypar",
+    "loky",
+    "networkx",
+    "opt_einsum",
+    "optuna",
+    "tqdm",
 ]
-docs = ["kahypar"]
 
 [project.urls]
 Homepage = "https://github.com/qiskit-community/qiskit-quimb"

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ commands =
 description = build docs
 extras =
   dev
-  docs
 setenv =
   SPHINX_APIDOC_OPTIONS = members,show-inheritance
 commands =


### PR DESCRIPTION
Adding these dependencies from https://cotengra.readthedocs.io/en/latest/installation.html# to avoid cotengra raising warning when running notebooks. Also stop bothering to separate dev and docs dependencies.